### PR TITLE
✨ refactor(user): harden BeforeCreate hook with validation, UUID gen, and panic recovery

### DIFF
--- a/entity/user_entity.go
+++ b/entity/user_entity.go
@@ -1,6 +1,9 @@
 package entity
 
 import (
+	"fmt"
+	"log"
+
 	"github.com/Caknoooo/go-gin-clean-starter/helpers"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -19,18 +22,24 @@ type User struct {
 	Timestamp
 }
 
-func (u *User) BeforeCreate(tx *gorm.DB) error {
+func (u *User) BeforeCreate(tx *gorm.DB) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			tx.Rollback()
+			log.Printf("panic recovered in BeforeCreate: %v", r)
+			err = fmt.Errorf("internal server error")
 		}
 	}()
 
-	var err error
-	// u.ID = uuid.New()
-	u.Password, err = helpers.HashPassword(u.Password)
-	if err != nil {
-		return err
+	if u.Password == "" {
+		return fmt.Errorf("password cannot be empty")
 	}
+	if u.ID == uuid.Nil {
+		u.ID = uuid.New()
+	}
+	hashedPassword, hashErr := helpers.HashPassword(u.Password)
+	if hashErr != nil {
+		return fmt.Errorf("failed to hash password: %w", hashErr)
+	}
+	u.Password = hashedPassword
 	return nil
 }


### PR DESCRIPTION
# 🚀Pull Request
## Description:
This PR refactors the GORM BeforeCreate hook on the User model to improve safety, correctness, and error handling:

### 🚫 Removed manual rollback

Rely on GORM’s built-in rollback on hook errors instead of calling tx.Rollback() manually.

### 🔒 Password validation

Returns an error if u.Password is empty, preventing creation of users without passwords.

### 🆔 UUID generation

If u.ID is still zero (uuid.Nil), assign a new uuid.New() before persisting.

### 🛡️ Panic recovery

Wrap the hook in defer+recover() to log and convert any unexpected panic into a controlled error (internal server error).

### 🧩 Error wrapping

Use Go’s %w to wrap hashing errors for better diagnostics.

